### PR TITLE
HelpMenu.py: check first if description attribute exists

### DIFF
--- a/lib/python/Screens/HelpMenu.py
+++ b/lib/python/Screens/HelpMenu.py
@@ -337,7 +337,7 @@ class HelpMenuList(List):
 				# print("[HelpMenu] Action map disabled.")
 				continue
 			amId = actMapId()
-			if headings and actionmap.description and not (formatFlags & self.HEADINGS):
+			if headings and hasattr(actionmap, "description") and not (formatFlags & self.HEADINGS):
 				# print("[HelpMenu] HelpMenuList DEBUG: Headings found.")
 				formatFlags |= self.HEADINGS
 			for (action, help) in actions:  # DEBUG: Should help be response?


### PR DESCRIPTION
if we use the spa keys remap module, first check if the description attribute exists.

https://openspa.info/threads/crash-al-pulsar-bot%C3%B3n-help-del-mando-y-encendidos-aleatorios.58071/post-480773