### PR TITLE
VideoMode.py: apply int method for this int with int operator

### DIFF
--- a/lib/python/Screens/VideoMode.py
+++ b/lib/python/Screens/VideoMode.py
@@ -716,7 +716,7 @@ class AutoVideoMode(Screen):
 					new_res = config_res
 					if video_pol == "p" and config_pol == "i":
 						new_pol = config_pol
-					if config_rate not in ("auto", "multi") and int(config_rate) < new_rate:
+					if config_rate not in ("auto", "multi") and int(config_rate) < int(new_rate):
 						new_rate = config_rate
 				new_rate = str(int(new_rate))
 


### PR DESCRIPTION
Otherwise the code compares an integer with a string.
00:16:18.3448     if config_rate not in ("auto", "multi") and int(config_rate) < new_rate:
00:16:18.3454                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
00:16:18.3455 TypeError: '<' not supported between instances of 'int' and 'str'
