### PR TITLE
NetworkSetup.py: Set your provider's DNS to first level

### DIFF
--- a/data/menu.xml
+++ b/data/menu.xml
@@ -75,7 +75,7 @@
 				<item key="usage_setup" level="0" text="Customize System Settings" weight="15"><setup setupKey="Usage" /></item>
 				<!--item key="specialfeatures_menu" level="0" text="Special Features Settings" weight="20"><setup setupKey="SpecialFeatures" /></item-->
 				<item key="skin_setup" level="0" text="Skin Settings" weight="25"><screen module="SkinSelector" screen="SkinSelector" /></item>
-				<item key="display_setup" level="0" text="Display Settings" weight="30" requires="DisplaySetup"><setup setupKey="Display" /></item>
+				<item key="display_setup" level="0" text="Display Settings" weight="30" requires="ConfigDisplay"><setup setupKey="Display" /></item>
 				<item key="led_setup" level="1" text="Configure front panel LEDs" weight="35" requires="LEDColorControl"><setup setupKey="LEDs" /></item>
 				<item key="lcd_skin_setup" level="0" text="LCD Skin Settings" weight="40" requires="LCDSKINSetup"><screen module="SkinSelector" screen="LcdSkinSelector" /></item>
 				<item key="input_device_setup" level="1" text="Input Devices Settings" weight="50"><screen module="InputDeviceSetup" screen="InputDeviceSelection" /></item>

--- a/data/menuspa.xml
+++ b/data/menuspa.xml
@@ -75,7 +75,7 @@
 				<item key="usage_setup" level="0" text="Customize System Settings" weight="15"><setup setupKey="Usage" /></item>
 				<!--item key="specialfeatures_menu" level="0" text="Special Features Settings" weight="20"><setup setupKey="SpecialFeatures" /></item-->
 				<item key="skin_setup" level="0" text="Skin Settings" weight="25"><screen module="SkinSelector" screen="SkinSelector" /></item>
-				<item key="display_setup" level="0" text="Display Settings" weight="30" requires="DisplaySetup"><setup setupKey="Display" /></item>
+				<item key="display_setup" level="0" text="Display Settings" weight="30" requires="ConfigDisplay"><setup setupKey="Display" /></item>
 				<item key="led_setup" level="1" text="Configure front panel LEDs" weight="35" requires="LEDColorControl"><setup setupKey="LEDs" /></item>
 				<item key="lcd_skin_setup" level="0" text="LCD Skin Settings" weight="40" requires="LCDSKINSetup"><screen module="SkinSelector" screen="LcdSkinSelector" /></item>
 				<item key="lcd_clock_setup" weight="10" level="0" text="LCD Clock selection" requires="LCDClockSetup"><screen module="LcdClockSelector" screen="LCDClockSelector"/></item>

--- a/lib/python/Screens/NetworkSetup.py
+++ b/lib/python/Screens/NetworkSetup.py
@@ -284,9 +284,10 @@ class DNSSettings(Setup):
 				config.usage.dns.value = option
 				dnsRefresh(refresh)
 				return option
-		option = "custom"
+		# option = "custom"  # OPENSPA Always configure a server after you have assigned DNS from your provider [norhap]
+		option = config.usage.dns.value  # OPENSPA now assign your DNS provider [norhap]
 		self.dnsOptions[option] = dnsServers[:]
-		config.usage.dns.value = option
+		# config.usage.dns.value = option  # OPENSPA this variable deprecated, use variable option [norhap]
 		dnsRefresh(refresh)
 		return option
 
@@ -3656,7 +3657,8 @@ class NetworkLogScreen(Screen):
 		self.console.killAll()
 		self.close(True)
 
-##############################Added by VillaK OpenSPA Udpxy and Xupnpd##########################################
+
+# #############################Added by VillaK OpenSPA Udpxy and Xupnpd##########################################
 class NetworkUdpxy(NetworkBaseScreen):
 	def __init__(self, session):
 		Screen.__init__(self, session)
@@ -3675,10 +3677,10 @@ class NetworkUdpxy(NetworkBaseScreen):
 		self.my_udpxy_active = False
 		self.my_udpxy_run = False
 		self['actions'] = HelpableActionMap(self,['WizardActions', 'ColorActions'], {
-			'ok': self.close, 
-			'back': self.close, 
-			'red': self.UninstallCheck, 
-			'green': self.UdpxyStartStop, 
+			'ok': self.close,
+			'back': self.close,
+			'red': self.UninstallCheck,
+			'green': self.UdpxyStartStop,
 			'yellow': self.activateUdpxy
 		},prio=0, description=_("Udpxy Actions"))
 		self.service_name = 'udpxy'
@@ -3686,7 +3688,7 @@ class NetworkUdpxy(NetworkBaseScreen):
 
 	def installComplete(self,result = None, retval = None, extra_args = None):
 		self.session.open(TryQuitMainloop, 2)
-		
+
 	def RemovedataAvail(self, str, retval, extra_args):
 		if str:
 			self.session.openWithCallback(self.RemovePackage, MessageBox, _("Your %s %s will be restarted after the removal of service\nDo you want to remove now?") % getBoxDisplayName(), MessageBox.TYPE_YESNO, windowTitle=_("Ready to remove '%s'?") % self.service_name)
@@ -3745,7 +3747,7 @@ class NetworkUdpxy(NetworkBaseScreen):
 		for cb in self.onChangedEntry:
 			cb(title, status_summary, autostartstatus_summary)
 
-###############################Xupnpd#################################
+# ##############################Xupnpd#################################
 class NetworkXupnpd(NetworkBaseScreen):
 	def __init__(self, session):
 		Screen.__init__(self, session)
@@ -3764,10 +3766,10 @@ class NetworkXupnpd(NetworkBaseScreen):
 		self.my_xupnpd_active = False
 		self.my_xupnpd_run = False
 		self['actions'] = HelpableActionMap(self,['WizardActions', 'ColorActions'], {
-			'ok': self.close, 
-			'back': self.close, 
-			'red': self.UninstallCheck, 
-			'green': self.xupnpdStartStop, 
+			'ok': self.close,
+			'back': self.close,
+			'red': self.UninstallCheck,
+			'green': self.xupnpdStartStop,
 			'yellow': self.activatexupnpd
 		},prio=0, description=_("Xupnpd Actions"))
 		self.service_name = 'xupnpd'
@@ -3775,7 +3777,7 @@ class NetworkXupnpd(NetworkBaseScreen):
 
 	def installComplete(self,result = None, retval = None, extra_args = None):
 		self.session.open(TryQuitMainloop, 2)
-		
+
 	def RemovedataAvail(self, str, retval, extra_args):
 		if str:
 			self.session.openWithCallback(self.RemovePackage, MessageBox, _("Your %s %s will be restarted after the removal of service\nDo you want to remove now?") % getBoxDisplayName(), MessageBox.TYPE_YESNO, windowTitle=_("Ready to remove '%s'?") % self.service_name)
@@ -3833,4 +3835,4 @@ class NetworkXupnpd(NetworkBaseScreen):
 
 		for cb in self.onChangedEntry:
 			cb(title, status_summary, autostartstatus_summary)
-###############################END added by OpenSPA#####################################
+# ##############################END added by OpenSPA#####################################


### PR DESCRIPTION

[NameserverSetup.txt](https://github.com/OpenSPA/dvbapp2/files/12820745/NameserverSetup.txt)
- This change sets your default DNS provider as first level and settings.
- Do not force the call to the dictionary to configure custom. Custom and other alternative DNS providers, it should always be below the level of your Internet DNS provider.
- PEP8 E265