### PR TITLE
Add video recovery function to 720p

### DIFF
--- a/data/keymap.xml
+++ b/data/keymap.xml
@@ -703,6 +703,7 @@
 		<key id="KEY_GREEN" mapto="aspectSelection" flags="l" />
 		<key id="KEY_MODE" mapto="aspectSelection" flags="l" />
 		<key id="KEY_MODE" mapto="aspectSelection" flags="b" />
+		<key id="KEY_EXIT" mapto="exitLong" flags="l" />
 	</map>
 
 	<map context="InfobarSubtitleSelectionActions">

--- a/lib/python/Screens/InfoBarGenerics.py
+++ b/lib/python/Screens/InfoBarGenerics.py
@@ -925,7 +925,7 @@ class InfoBarShowHide(InfoBarScreenSaver):
 		if self.LongButtonPressed:
 			self.longpress(config.usage.oklong.value)
 		###############################################
-		
+
 	def lockShow(self):
 		try:
 			self.__locked += 1
@@ -3219,7 +3219,7 @@ class InfoBarExtensions:
 		else:
 			return []
 	########################################
-	
+
 	## OPENSPA [evox] Add Ipk Uninstall Tool
 	def getIpkUninstallname(self):
 		return _("Ipk Uninstall Tool")
@@ -3235,7 +3235,7 @@ class InfoBarExtensions:
 			else:
 				for y in elem[1]():
 					name =str(y[0][0]())
-			return name			
+			return name
 	########################################
 
 	def addExtension(self, extension, key=None, type=EXTENSION_SINGLE):
@@ -3730,7 +3730,7 @@ class InfoBarInstantRecord:
 			from Screens.TimerEdit import TimerEditList
 			self.session.open(TimerEditList)
 		elif value == "resolution":
-			self.ExGreen_toggleGreen()		
+			self.ExGreen_toggleGreen()
 		elif value == "camdmanager":
 			try:
 				from Plugins.Extensions.spazeMenu.spzPlugins.spzCAMD.plugin import startConfig
@@ -4343,6 +4343,7 @@ class InfoBarAspectSelection:
 	def __init__(self):
 		self["AspectSelectionAction"] = HelpableActionMap(self, "InfobarAspectSelectionActions", {
 			"aspectSelection": (self.GreenLongPress, _("Aspect list...")),
+			"exitLong": (self.switchTo720p, _("Switch to 720p video")),
 		}, prio=0, description=_("Aspect Ratio Actions"))
 
 		self.__ExGreen_state = self.STATE_HIDDEN
@@ -4444,6 +4445,20 @@ class InfoBarAspectSelection:
 		else:
 			self.ExGreen_doHide()
 
+	def changeVideoMode(self, confirmed):  # [OPENSPA] [norhap]
+		port = config.av.videoport.value
+		mode = config.av.videomode[port].value
+		rate = config.av.videorate[mode].value
+		self.last_used_video_mode = (port, mode, rate)  # have video 720p
+		if not confirmed:   # return to the last used video mode
+			config.av.videoport.value = self.last_used_video_mode[0]
+			config.av.videomode[self.last_used_video_mode[0]].value = self.last_used_video_mode[1]
+			config.av.videorate[self.last_used_video_mode[1]].value = self.last_used_video_mode[2]
+			iAVSwitch.setMode(*self.last_used_video_mode)
+
+	def switchTo720p(self):  # use 720p video mode recover signal on your video port
+		iAVSwitch.setMode("HDMI", "720p", "50Hz")
+		self.session.openWithCallback(self.changeVideoMode, MessageBox, _("This function recovers your video signal in case of loss. The video has been changed to 720p.\nIf this is your case, please keep the video at 720P and do the following:\nGo to System > Receiver Setup > Video > Video Settings\nNow set a correct resolution.\n\nDo you want to keep the video at 720p?"), MessageBox.TYPE_YESNO, timeout=30, simple=True)
 
 class InfoBarResolutionSelection:
 	def __init__(self):

--- a/po/es.po
+++ b/po/es.po
@@ -21483,6 +21483,9 @@ msgstr ""
 "Esta función no está disponible ya que el procesado de archivos grandes "
 "puede llevar mucho tiempo al ejecutar en este hardware."
 
+msgid "This function recovers your video signal in case of loss. The video has been changed to 720p.\nIf this is your case, please keep the video at 720P and do the following:\nGo to System > Receiver Setup > Video > Video Settings\nNow set a correct resolution.\n\nDo you want to keep the video at 720p?"
+msgstr "Esta función recupera su señal de video en caso de pérdida. El vídeo se ha cambiado a 720p.\nSi este es su caso, mantenga el vídeo en 720P y haz lo siguiente:\nVaya a Sistema > Configuración del receptor > Vídeo > Ajustes de vídeo\nAhora configure una resolución correcta.\n\n¿Quieres mantener el vídeo a 720p?"
+
 msgid ""
 "This is a workaround for some devices that wake up again after switching to "
 "standby. The wake up command's from other devices will be ignored for few "


### PR DESCRIPTION
This change gives the possibility of putting the system in video recovery mode, setting standard video at 720p in order to recover the video in case of signal loss on the HDMI port.

The function has two main objectives:
If we change the receiver to a Television with a resolution not supported in the established and saved in the receiver we do not have a signal, before the conventional way was to recover the signal through another program (OpenWebIf) accessing through OSD, now the user can press Long press the EXIT button to access this recovery, displaying a message indicating the instructions to follow and do it all through the remote control and the interface.

The other possible use is to try to recover video through enigma in case the receiver loses it either due to drivers supporting unavailable modes, or due to failures in the HDMI cables used.